### PR TITLE
fix: Compatibility adjustments with PHP 8.0, 8.1 and 8.2.

### DIFF
--- a/php_blenc.h
+++ b/php_blenc.h
@@ -26,10 +26,17 @@
 #define PHP_ZEND_ENGINE_7_0
 #endif
 
-#if ZEND_MODULE_API_NO >= 20200930
+#if ZEND_MODULE_API_NO >= 20200930 && ZEND_MODULE_API_NO < 20210902
 #define PHP_ZEND_ENGINE_8_0
 #endif
 
+#if ZEND_MODULE_API_NO >= 20210902 && ZEND_MODULE_API_NO < 20220829
+#define PHP_ZEND_ENGINE_8_1
+#endif
+
+#if ZEND_MODULE_API_NO >= 20220829
+#define PHP_ZEND_ENGINE_8_2
+#endif
 
 #define PHP_BLENC_VERSION "1.1.4b"
 #define BLENC_IDENT "BLENC"
@@ -101,7 +108,7 @@ void (*old_stream_closer)(void * TSRMLS_DC);
 #ifdef PHP_ZEND_ENGINE_7_0
 zend_op_array *(*zend_compile_file_old)(zend_file_handle *, int TSRMLS_DC);
 #endif
-#ifdef PHP_ZEND_ENGINE_8_0
+#if defined(PHP_ZEND_ENGINE_8_0) || defined(PHP_ZEND_ENGINE_8_1) || defined(PHP_ZEND_ENGINE_8_2)
 zend_op_array *(*zend_compile_file_old)(zend_file_handle *, int type);
 #endif
 zend_op_array *blenc_compile(zend_file_handle *, int TSRMLS_DC);


### PR DESCRIPTION
Hello,

@illuusio I increased the compatibility settings with PHP > 8 up to 8.2 added their tweaks as well.

Apparently everything is ok. I made adjustments according to the change of **zend_compile_string**.

I had doubts about the last parameter, position. I changed it to work in my local tests and tests for this extension. If you use **ZEND_COMPILE_POSITION_AT_SHEBANG** or **ZEND_COMPILE_POSITION_AT_OPEN_TAG** the tests break.

Well, check the changes and tests please.

Thank you and see you later.